### PR TITLE
Add Copilot badge and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # copycat
 copycat for youtube
 
+![GitHub Copilot](https://img.shields.io/badge/GitHub-Copilot-blue?logo=github)
 
 ## Resources
 [on creative commons on youtube](https://www.youtube.com/watch?v=kBG-RnZU2cQ)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # copycat
 copycat for youtube
 
-![build with Copilot Workspace](https://img.shields.io/badge/build%20with-Copilot%20Workspace-blue?logo=github)
+![build with Copilot Workspace](https://img.shields.io/badge/build%20with-Copilot%20Workspace-blue?logo=github&link=https://githubnext.com/projects/copilot-workspace)
 
 ## Resources
 [on creative commons on youtube](https://www.youtube.com/watch?v=kBG-RnZU2cQ)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # copycat
 copycat for youtube
 
-![GitHub Copilot](https://img.shields.io/badge/GitHub-Copilot-blue?logo=github)
+![build with Copilot Workspace](https://img.shields.io/badge/build%20with-Copilot%20Workspace-blue?logo=github)
 
 ## Resources
 [on creative commons on youtube](https://www.youtube.com/watch?v=kBG-RnZU2cQ)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # copycat
 copycat for youtube
 
-![build with Copilot Workspace](https://img.shields.io/badge/build%20with-Copilot%20Workspace-blue?logo=github&link=https://githubnext.com/projects/copilot-workspace)
+[![build with Copilot Workspace](https://img.shields.io/badge/build%20with-Copilot%20Workspace-blue?logo=github)](https://githubnext.com/projects/copilot-workspace)
 
 ## Resources
 [on creative commons on youtube](https://www.youtube.com/watch?v=kBG-RnZU2cQ)


### PR DESCRIPTION
Fixes #1

Add a badge to indicate the use of GitHub Copilot in the `README.md`.

* Add a badge to the top of the `README.md` file to indicate the use of GitHub Copilot.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/adriandavidauer/copycat/pull/3?shareId=51b05289-e43c-4317-9735-8cc6bde937be).